### PR TITLE
fix: peer errors by removing stylistic-ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ alt="platformatic"
 * Migrate `eslint-plugin-promise` rules from `standard`: [#14](https://github.com/neostandard/neostandard/issues/14)
 * Migrate `eslint-plugin-import` rules from `standard`: [#15](https://github.com/neostandard/neostandard/issues/15)
 * Investigate a dedicated `neostandard` runner: [#2](https://github.com/neostandard/neostandard/issues/2)
+* Style rules for TypeScript files: [eslint-stylistic#414](https://github.com/eslint-stylistic/eslint-stylistic/issues/414)
 
 Full list in [1.0.0 milestone](https://github.com/neostandard/neostandard/milestone/1)
 

--- a/lib/configs/style.js
+++ b/lib/configs/style.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // Currently @stylistic/eslint-plugin is not type compatible with @typescript-eslint/utils/ts-eslint').FlatConfig.Plugin
-const stylistic = /** @type {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Plugin} */ (/** @type {unknown} */(require('@stylistic/eslint-plugin')))
+const stylistic = /** @type {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Plugin} */ (/** @type {unknown} */(require('@stylistic/eslint-plugin-js')))
 
 module.exports = /** @satisfies {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Config} */ ({
   plugins: {

--- a/lib/ts.js
+++ b/lib/ts.js
@@ -3,6 +3,7 @@
 const tsEslintPlugin = require('@typescript-eslint/eslint-plugin')
 const { config, parser } = require('typescript-eslint')
 
+const style = require('./configs/style.js')
 const tsRedundant = require('./configs/ts-redundant')
 
 /**
@@ -33,6 +34,12 @@ function typescriptify (configs, options) {
 
   for (const config of configs) {
     for (const ruleId in tsRedundant) {
+      if (config.rules?.[ruleId]) {
+        deactivatedRules[ruleId] = 'off'
+      }
+    }
+    // TODO: Readd when https://github.com/eslint-stylistic/eslint-stylistic/issues/414 is fixed
+    for (const ruleId in style.rules) {
       if (config.rules?.[ruleId]) {
         deactivatedRules[ruleId] = 'off'
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
-        "@stylistic/eslint-plugin": "^2.1.0",
+        "@stylistic/eslint-plugin-js": "^2.1.0",
         "@typescript-eslint/eslint-plugin": "^8.0.0-alpha.26",
         "@typescript-eslint/utils": "^8.0.0-alpha.26",
         "eslint-plugin-n": "^17.0.0",
@@ -570,28 +570,11 @@
         "node": ">=8.10"
       }
     },
-    "node_modules/@stylistic/eslint-plugin": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-2.1.0.tgz",
-      "integrity": "sha512-cBBowKP2u/+uE5CzgH5w8pE9VKqcM7BXdIDPIbGt2rmLJGnA6MJPr9vYGaqgMoJFs7R/FzsMQerMvvEP40g2uw==",
-      "dependencies": {
-        "@stylistic/eslint-plugin-js": "2.1.0",
-        "@stylistic/eslint-plugin-jsx": "2.1.0",
-        "@stylistic/eslint-plugin-plus": "2.1.0",
-        "@stylistic/eslint-plugin-ts": "2.1.0",
-        "@types/eslint": "^8.56.10"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=8.40.0"
-      }
-    },
     "node_modules/@stylistic/eslint-plugin-js": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-2.1.0.tgz",
       "integrity": "sha512-gdXUjGNSsnY6nPyqxu6lmDTtVrwCOjun4x8PUn0x04d5ucLI74N3MT1Q0UhdcOR9No3bo5PGDyBgXK+KmD787A==",
+      "license": "MIT",
       "dependencies": {
         "@types/eslint": "^8.56.10",
         "acorn": "^8.11.3",
@@ -603,257 +586,6 @@
       },
       "peerDependencies": {
         "eslint": ">=8.40.0"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-jsx": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-2.1.0.tgz",
-      "integrity": "sha512-mMD7S+IndZo2vxmwpHVTCwx2O1VdtE5tmpeNwgaEcXODzWV1WTWpnsc/PECQKIr/mkLPFWiSIqcuYNhQ/3l6AQ==",
-      "dependencies": {
-        "@stylistic/eslint-plugin-js": "^2.1.0",
-        "@types/eslint": "^8.56.10",
-        "estraverse": "^5.3.0",
-        "picomatch": "^4.0.2"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=8.40.0"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-plus": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-2.1.0.tgz",
-      "integrity": "sha512-S5QAlgYXESJaSBFhBSBLZy9o36gXrXQwWSt6QkO+F0SrT9vpV5JF/VKoh+ojO7tHzd8Ckmyouq02TT9Sv2B0zQ==",
-      "dependencies": {
-        "@types/eslint": "^8.56.10",
-        "@typescript-eslint/utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "eslint": "*"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-plus/node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.12.0.tgz",
-      "integrity": "sha512-itF1pTnN6F3unPak+kutH9raIkL3lhH1YRPGgt7QQOh43DQKVJXmWkpb+vpc/TiDHs6RSd9CTbDsc/Y+Ygq7kg==",
-      "dependencies": {
-        "@typescript-eslint/types": "7.12.0",
-        "@typescript-eslint/visitor-keys": "7.12.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-plus/node_modules/@typescript-eslint/types": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.12.0.tgz",
-      "integrity": "sha512-o+0Te6eWp2ppKY3mLCU+YA9pVJxhUJE15FV7kxuD9jgwIAa+w/ycGJBMrYDTpVGUM/tgpa9SeMOugSabWFq7bg==",
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-plus/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.12.0.tgz",
-      "integrity": "sha512-5bwqLsWBULv1h6pn7cMW5dXX/Y2amRqLaKqsASVwbBHMZSnHqE/HN4vT4fE0aFsiwxYvr98kqOWh1a8ZKXalCQ==",
-      "dependencies": {
-        "@typescript-eslint/types": "7.12.0",
-        "@typescript-eslint/visitor-keys": "7.12.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^1.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-plus/node_modules/@typescript-eslint/utils": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.12.0.tgz",
-      "integrity": "sha512-Y6hhwxwDx41HNpjuYswYp6gDbkiZ8Hin9Bf5aJQn1bpTs3afYY4GX+MPYxma8jtoIV2GRwTM/UJm/2uGCVv+DQ==",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "7.12.0",
-        "@typescript-eslint/types": "7.12.0",
-        "@typescript-eslint/typescript-estree": "7.12.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.56.0"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-plus/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.12.0.tgz",
-      "integrity": "sha512-uZk7DevrQLL3vSnfFl5bj4sL75qC9D6EdjemIdbtkuUmIheWpuiiylSY01JxJE7+zGrOWDZrp1WxOuDntvKrHQ==",
-      "dependencies": {
-        "@typescript-eslint/types": "7.12.0",
-        "eslint-visitor-keys": "^3.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-plus/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-ts": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-2.1.0.tgz",
-      "integrity": "sha512-2ioFibufHYBALx2TBrU4KXovCkN8qCqcb9yIHc0fyOfTaO5jw4d56WW7YRcF3Zgde6qFyXwAN6z/+w4pnmos1g==",
-      "dependencies": {
-        "@stylistic/eslint-plugin-js": "2.1.0",
-        "@types/eslint": "^8.56.10",
-        "@typescript-eslint/utils": "^7.8.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=8.40.0"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-ts/node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.12.0.tgz",
-      "integrity": "sha512-itF1pTnN6F3unPak+kutH9raIkL3lhH1YRPGgt7QQOh43DQKVJXmWkpb+vpc/TiDHs6RSd9CTbDsc/Y+Ygq7kg==",
-      "dependencies": {
-        "@typescript-eslint/types": "7.12.0",
-        "@typescript-eslint/visitor-keys": "7.12.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-ts/node_modules/@typescript-eslint/types": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.12.0.tgz",
-      "integrity": "sha512-o+0Te6eWp2ppKY3mLCU+YA9pVJxhUJE15FV7kxuD9jgwIAa+w/ycGJBMrYDTpVGUM/tgpa9SeMOugSabWFq7bg==",
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-ts/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.12.0.tgz",
-      "integrity": "sha512-5bwqLsWBULv1h6pn7cMW5dXX/Y2amRqLaKqsASVwbBHMZSnHqE/HN4vT4fE0aFsiwxYvr98kqOWh1a8ZKXalCQ==",
-      "dependencies": {
-        "@typescript-eslint/types": "7.12.0",
-        "@typescript-eslint/visitor-keys": "7.12.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^1.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-ts/node_modules/@typescript-eslint/utils": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.12.0.tgz",
-      "integrity": "sha512-Y6hhwxwDx41HNpjuYswYp6gDbkiZ8Hin9Bf5aJQn1bpTs3afYY4GX+MPYxma8jtoIV2GRwTM/UJm/2uGCVv+DQ==",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "7.12.0",
-        "@typescript-eslint/types": "7.12.0",
-        "@typescript-eslint/typescript-estree": "7.12.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.56.0"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-ts/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.12.0.tgz",
-      "integrity": "sha512-uZk7DevrQLL3vSnfFl5bj4sL75qC9D6EdjemIdbtkuUmIheWpuiiylSY01JxJE7+zGrOWDZrp1WxOuDntvKrHQ==",
-      "dependencies": {
-        "@typescript-eslint/types": "7.12.0",
-        "eslint-visitor-keys": "^3.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-ts/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@szmarczak/http-timer": {
@@ -872,6 +604,7 @@
       "version": "8.56.10",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
       "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -880,7 +613,8 @@
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "license": "MIT"
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
@@ -891,7 +625,8 @@
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "18.19.34",
@@ -1842,6 +1577,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -3305,6 +3041,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
-    "@stylistic/eslint-plugin": "^2.1.0",
+    "@stylistic/eslint-plugin-js": "^2.1.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0-alpha.26",
     "@typescript-eslint/utils": "^8.0.0-alpha.26",
     "eslint-plugin-n": "^17.0.0",


### PR DESCRIPTION
ESLint Stylistics TypeScript rykes still rely on typescript-eslint@7.x which in turn requires ESLint 8.x, which conflicts with our requirement of ESLint 9.x

See https://github.com/eslint-stylistic/eslint-stylistic/issues/414

Fixes #35