### PR TITLE
test: validate strict peer dependency installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 !/lib/**/*-types.d.ts
 
 # Library specific ones
+/install-test-*

--- a/.knip.jsonc
+++ b/.knip.jsonc
@@ -3,5 +3,8 @@
   "entry": [
     "index.js",
     "index.d.ts"
+  ],
+  "ignoreBinaries": [
+    "pwd"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "prepublishOnly": "run-s build",
     "test-ci": "run-s test:*",
     "test:eslint": "eslint .",
+    "test:install": "NEOSTANDARD_PATH=`pwd` && cd $(mktemp -d -p $NEOSTANDARD_PATH install-test-XXXXXXXXXX) && npm init -y && npm install --no-legacy-peer-deps --package-lock-only --strict-peer-deps --install-links eslint $NEOSTANDARD_PATH",
     "test": "run-s check test:*"
   },
   "devDependencies": {


### PR DESCRIPTION
Had to add `--no-legacy-peer-deps` in the npm script as for some reason my npm kept adding `$npm_config_legacy_peer_deps` that was set to `true` within all my npm scripts