### PR TITLE
fix!: remove built in ignores + fix ignores in `*.ts`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ alt="platformatic"
   * [Migrate from `standard`](#migrate-from-standard)
   * [Add to new project](#add-to-new-project)
 * [Configuration options](#configuration-options)
+* [resolveIgnoresFromGitignore()](#resolveignoresfromgitignore)
 * [Missing for 1.0.0 release](#missing-for-100-release)
 * [Differences to standard / eslint-config-standard 17.x](#differences-to-standard--eslint-config-standard-17x)
   * [Changed rules](#changed-rules)
@@ -95,10 +96,31 @@ alt="platformatic"
 * `env` - *`string[]`* - adds additional globals by importing them from the [globals](https://www.npmjs.com/package/globals) npm module
 * `globals` - *`string[] | object`* - an array of names of globals or an object of the same shape as ESLint [`languageOptions.globals`](https://eslint.org/docs/latest/use/configure/language-options#using-configuration-files)
 * `ignores` - *`string[]`* - an array of glob patterns for files that the config should not apply to, see [ESLint documentation](https://eslint.org/docs/latest/use/configure/ignore) for details
-* `noDefaultIgnore` - *`boolean`* - opts out of default `ignores` that `neostandard` adds (`**/*.min.js`, `coverage/**/*` as well as everything in the project's `.gitignore`)
 * `noStyle` - *`boolean`* - if set, no style rules will be added. Especially useful when combined with [Prettier](https://prettier.io/), [dprint](https://dprint.dev/) or similar
 * `semi` - *`boolean`* - if set, enforce rather than forbid semicolons (same as `semistandard` did)
 * `ts` - *`boolean`* - if set, `.ts` (and `.d.ts`) files will be checked
+
+## resolveIgnoresFromGitignore()
+
+Finds a `.gitignore` file that recides in the same directory as the ESLint config file and returns an array of ESLint ignores that matches the same files.
+
+ESM:
+
+```js
+import neostandard, { resolveIgnoresFromGitignore } from 'neostandard'
+
+export default neostandard({
+  ignores: resolveIgnoresFromGitignore(),
+})
+```
+
+CommonJS:
+
+```js
+module.exports = require('neostandard')({
+  ignores: require('neostandard').resolveIgnoresFromGitignore(),
+})
+```
 
 ## Missing for 1.0.0 release
 

--- a/cli.mjs
+++ b/cli.mjs
@@ -45,11 +45,6 @@ const {
       multiple: true,
       short: 'i',
     },
-    'no-default-ignore': {
-      listGroup: 'Config options',
-      description: 'Deactivates the default ingores that neostandard adds',
-      type: 'boolean',
-    },
     'no-style': {
       listGroup: 'Config options',
       description: 'Deactivates all style linting',
@@ -83,7 +78,6 @@ const flagMapping = /** @satisfies {Record<keyof typeof flags, keyof import('./i
   env: 'env',
   global: 'globals',
   ignore: 'ignores',
-  'no-default-ignore': 'noDefaultIgnore',
   'no-style': 'noStyle',
   semi: 'semi',
   ts: 'ts',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,3 +1,6 @@
 'use strict'
 
-module.exports = require('./')({ ts: true })
+module.exports = require('./')({
+  ignores: require('./').resolveIgnoresFromGitignore(),
+  ts: true,
+})

--- a/index.js
+++ b/index.js
@@ -3,3 +3,5 @@
 /** @typedef {import('./lib/main').NeostandardOptions} NeostandardOptions */
 
 module.exports = require('./lib/main').neostandard
+
+module.exports.resolveIgnoresFromGitignore = require('./lib/resolve-gitignore').resolveIgnoresFromGitignore

--- a/lib/config-extend.js
+++ b/lib/config-extend.js
@@ -1,0 +1,49 @@
+/**
+ * @typedef ConfigExtensions
+ * @property {import('typescript-eslint').ConfigWithExtends['files']} [files]
+ * @property {import('@typescript-eslint/utils/ts-eslint').FlatConfig.GlobalsConfig|undefined} [globals]
+ * @property {string[]|undefined} [ignores]
+ */
+
+/**
+ * @param {import('@typescript-eslint/utils/ts-eslint').FlatConfig.ConfigArray} configs
+ * @param {ConfigExtensions} extensions
+ * @returns {import('@typescript-eslint/utils/ts-eslint').FlatConfig.ConfigArray}
+ */
+function configExtend (configs, { files, globals, ignores }) {
+  if (!files && !globals && !ignores) {
+    return configs
+  }
+
+  /** @type {import('@typescript-eslint/utils/ts-eslint').FlatConfig.ConfigArray} */
+  const result = []
+
+  for (const config of configs) {
+    /** @type {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Config} */
+    const extension = {
+      ...files && { files: [...files, ...config.files || []] },
+      ...ignores && { ignores: [...ignores, ...config.ignores || []] },
+    }
+
+    if (globals) {
+      extension.languageOptions = {
+        ...config.languageOptions,
+        globals: {
+          ...config.languageOptions?.globals,
+          ...globals,
+        },
+      }
+    }
+
+    result.push({
+      ...config,
+      ...extension,
+    })
+  }
+
+  return result
+}
+
+module.exports = {
+  configExtend,
+}

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,31 +1,34 @@
 'use strict'
 
-const { config } = require('typescript-eslint')
 const globals = require('globals')
 
-const base = require('./configs/base.js')
+const base = require('./configs/base')
 const {
   modernization,
   modernizationStyles,
-} = require('./configs/modernization.js')
-const semiConfig = require('./configs/semi.js')
-const style = require('./configs/style.js')
-const { resolveIgnoresFromGitignore } = require('./resolve-gitignore')
-const { typescriptify } = require('./ts.js')
+} = require('./configs/modernization')
+const semiConfig = require('./configs/semi')
+const style = require('./configs/style')
+const { configExtend } = require('./config-extend')
+const { typescriptify } = require('./ts')
 
 // TODO: Ensure both commonjs and esm are evaluated properly: https://github.com/eslint/eslint/discussions/18300#discussioncomment-9062217 And how does it interact with TS?
 
-const DEFAULT_IGNORE = /** @type {const} */ ([
-  '**/*.min.js',
-  'coverage/**',
-])
+const DEFAULT_FILES = [
+  '**/*.js',
+  '**/*.cjs',
+  '**/*.mjs',
+]
+
+const DEFAULT_TS_FILES = [
+  '**/*.ts',
+]
 
 /**
  * @typedef NeostandardOptions
  * @property {Array<keyof import('globals')>|undefined} [env]
  * @property {import('@typescript-eslint/utils/ts-eslint').FlatConfig.GlobalsConfig|string[]|undefined} [globals]
  * @property {string[]|undefined} [ignores]
- * @property {boolean|undefined} [noDefaultIgnore] - opts out of the default ignores
  * @property {boolean|undefined} [noStyle] - skip style rules
  * @property {boolean|undefined} [semi] - enforce rather than forbid semicolons
  * @property {boolean|undefined} [ts] - enable TypeScript checks
@@ -39,8 +42,7 @@ function neostandard (options) {
   const {
     env,
     globals: rawGlobals,
-    ignores: rawIgnores,
-    noDefaultIgnore = false,
+    ignores,
     noStyle = false,
     ts = false,
     semi = false,
@@ -69,30 +71,27 @@ function neostandard (options) {
         ...(semi ? [semiConfig] : []),
       ]
 
-  const ignores = [...new Set([
-    ...(noDefaultIgnore ? [] : DEFAULT_IGNORE),
-    ...(noDefaultIgnore ? [] : resolveIgnoresFromGitignore()),
-    ...rawIgnores || [],
-  ])]
+  const jsConfigs = [
+    base,
+    modernization,
+    ...styleConfigs,
+  ]
 
-  const resolved = config({
-    ...resolvedGlobals && {
-      languageOptions: {
-        globals: resolvedGlobals,
-      },
-    },
+  const configs = configExtend(jsConfigs, {
+    files: ts ? [...DEFAULT_FILES, ...DEFAULT_TS_FILES] : DEFAULT_FILES,
+    globals: Object.keys(resolvedGlobals).length ? resolvedGlobals : undefined,
     ignores,
-    extends: [
-      base,
-      modernization,
-      ...styleConfigs,
-    ],
   })
 
-  return [
-    ...resolved,
-    ...(ts ? typescriptify(resolved, { files: ['**/*.ts'] }) : []),
-  ]
+  if (ts) {
+    configs.push(typescriptify(configs, {
+      files: DEFAULT_TS_FILES,
+      ignores,
+      name: 'Neostandard TypeScript Adaptions',
+    }))
+  }
+
+  return configs
 }
 
 module.exports = {

--- a/lib/resolve-gitignore.js
+++ b/lib/resolve-gitignore.js
@@ -26,14 +26,17 @@ function findFlatConfigFileSync () {
 }
 
 /**
- * @returns {Generator<string, undefined>}
+ * @returns {string[]}
  */
-function * resolveIgnoresFromGitignore () {
+function resolveIgnoresFromGitignore () {
   const configFile = findFlatConfigFileSync()
 
   if (!configFile) {
-    return
+    return []
   }
+
+  /** @type {string[]} */
+  const result = []
 
   try {
     const content = readFileSync(path.join(path.dirname(configFile), '.gitignore'), 'utf8')
@@ -42,10 +45,12 @@ function * resolveIgnoresFromGitignore () {
       line = line.trim()
 
       if (line && !line.startsWith('#')) {
-        yield gitignoreToMinimatch(line)
+        result.push(gitignoreToMinimatch(line))
       }
     }
   } catch {}
+
+  return result
 }
 
 module.exports = {

--- a/lib/ts.js
+++ b/lib/ts.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const tsEslintPlugin = require('@typescript-eslint/eslint-plugin')
-const { config, parser } = require('typescript-eslint')
+const { parser } = require('typescript-eslint')
 
 const style = require('./configs/style.js')
 const tsRedundant = require('./configs/ts-redundant')
@@ -9,6 +9,8 @@ const tsRedundant = require('./configs/ts-redundant')
 /**
  * @typedef TypescriptifyOptions
  * @property {import('typescript-eslint').ConfigWithExtends['files']} [files]
+ * @property {string[]|undefined} [ignores]
+ * @property {string} [name]
  * @property {string[] | string | boolean | null} [project]
  * @property {string} [tsconfigRootDir]
  * @property {boolean} [typeChecking]
@@ -17,11 +19,13 @@ const tsRedundant = require('./configs/ts-redundant')
 /**
  * @param {import('@typescript-eslint/utils/ts-eslint').FlatConfig.ConfigArray} configs
  * @param {TypescriptifyOptions} options
- * @returns {import('@typescript-eslint/utils/ts-eslint').FlatConfig.ConfigArray}
+ * @returns {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Config}
  */
 function typescriptify (configs, options) {
   const {
-    files = ['**/*.{js,mjs,cjs,ts}'],
+    files,
+    ignores,
+    name,
     project,
     tsconfigRootDir,
     typeChecking = false,
@@ -67,6 +71,9 @@ function typescriptify (configs, options) {
   }
 
   const result = /** @satisfies {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Config} */ ({
+    ...name && { name },
+    ...files && { files },
+    ...ignores && { ignores },
     languageOptions: {
       parser,
       parserOptions: {
@@ -83,11 +90,7 @@ function typescriptify (configs, options) {
     },
   })
 
-  return config({
-    files,
-    extends: configs,
-    ...result,
-  })
+  return result
 }
 
 module.exports = {


### PR DESCRIPTION
And generally make the configs more understandable in the config inspector

Also:

- Export `resolveIgnoresFromGitignore()` to enable easy gitignore ignoring

Fixes #34