### PR TITLE
fix: make config names conform to name convention

### DIFF
--- a/lib/configs/base.js
+++ b/lib/configs/base.js
@@ -4,7 +4,7 @@ const globals = require('globals')
 const eslintPluginN = require('eslint-plugin-n')
 
 module.exports = /** @satisfies {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Config} */ ({
-  name: 'Neostandard Base',
+  name: 'neostandard/base',
 
   languageOptions: {
     ecmaVersion: 2022,

--- a/lib/configs/modernization.js
+++ b/lib/configs/modernization.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports.modernization = /** @satisfies {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Config} */ ({
-  name: 'Neostandard Modernization (changes from Standard 17)',
+  name: 'neostandard/modernization-since-standard-17',
 
   rules: {
     'dot-notation': 'off',
@@ -17,7 +17,7 @@ module.exports.modernization = /** @satisfies {import('@typescript-eslint/utils/
 })
 
 module.exports.modernizationStyles = /** @satisfies {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Config} */ ({
-  name: 'Neostandard Style Modernization (changes from Standard 17)',
+  name: 'neostandard/style/modernization-since-standard-17',
 
   rules: {
     '@stylistic/comma-dangle': ['warn', {

--- a/lib/configs/semi.js
+++ b/lib/configs/semi.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = /** @satisfies {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Config} */({
-  name: 'Neostandard Semi',
+  name: 'neostandard/semi',
 
   rules: {
     '@stylistic/semi': ['error', 'always'],

--- a/lib/configs/style.js
+++ b/lib/configs/style.js
@@ -4,7 +4,7 @@
 const stylistic = /** @type {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Plugin} */ (/** @type {unknown} */(require('@stylistic/eslint-plugin-js')))
 
 module.exports = /** @satisfies {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Config} */ ({
-  name: 'Neostandard Style',
+  name: 'neostandard/style',
 
   plugins: {
     '@stylistic': stylistic,

--- a/lib/main.js
+++ b/lib/main.js
@@ -87,7 +87,7 @@ function neostandard (options) {
     configs.push(typescriptify(configs, {
       files: DEFAULT_TS_FILES,
       ignores,
-      name: 'Neostandard TypeScript Adaptions',
+      name: 'neostandard/ts',
     }))
   }
 


### PR DESCRIPTION
See https://eslint.org/docs/latest/use/configure/configuration-files#configuration-naming-conventions

New names are slash-separated and lower case