### PR TITLE
fix!: export `typescript-eslint` instead of `@typescript-eslint/eslint-…

### DIFF
--- a/.knip.jsonc
+++ b/.knip.jsonc
@@ -8,6 +8,7 @@
     "pwd"
   ],
   "ignore": [
-    "test/should-*/**/*"
+    "test/should-*/**/*",
+    "test/ts-extension-eslint.config.mjs"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ module.exports = require('neostandard')({
 #### List of exported plugins
 
 * `@stylistic` - export of [`@stylistic/eslint-plugin`](https://npmjs.com/package/@stylistic/eslint-plugin)
-* `@typescript-eslint` - export of [`@typescript-eslint/eslint-plugin`](https://npmjs.com/package/@typescript-eslint/eslint-plugin)
+* `typescript-eslint` - export of [`typescript-eslint`](https://npmjs.com/package/typescript-eslint)
 * `n` - export of [`eslint-plugin-n`](https://npmjs.com/package/eslint-plugin-n)
 * `promise` - export of [`eslint-plugin-promise`](https://npmjs.com/package/eslint-plugin-promise)
 

--- a/README.md
+++ b/README.md
@@ -135,9 +135,9 @@ module.exports = require('neostandard')({
 #### List of exported plugins
 
 * `@stylistic` - export of [`@stylistic/eslint-plugin`](https://npmjs.com/package/@stylistic/eslint-plugin)
-* `typescript-eslint` - export of [`typescript-eslint`](https://npmjs.com/package/typescript-eslint)
 * `n` - export of [`eslint-plugin-n`](https://npmjs.com/package/eslint-plugin-n)
 * `promise` - export of [`eslint-plugin-promise`](https://npmjs.com/package/eslint-plugin-promise)
+* `typescript-eslint` - export of [`typescript-eslint`](https://npmjs.com/package/typescript-eslint)
 
 #### Usage of exported plugin
 

--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@ module.exports.plugins = /** @type {const} */ ({
   get '@stylistic' () {
     return require('@stylistic/eslint-plugin')
   },
-  get '@typescript-eslint' () {
-    return require('@typescript-eslint/eslint-plugin')
+  get 'typescript-eslint' () {
+    return require('typescript-eslint')
   },
   get n () {
     return require('eslint-plugin-n')

--- a/index.js
+++ b/index.js
@@ -10,14 +10,14 @@ module.exports.plugins = /** @type {const} */ ({
   get '@stylistic' () {
     return require('@stylistic/eslint-plugin')
   },
-  get 'typescript-eslint' () {
-    return require('typescript-eslint')
-  },
   get n () {
     return require('eslint-plugin-n')
   },
   get promise () {
     // @ts-ignore
     return require('eslint-plugin-promise')
+  },
+  get 'typescript-eslint' () {
+    return require('typescript-eslint')
   },
 })

--- a/lib/ts.js
+++ b/lib/ts.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const tsEslintPlugin = require('@typescript-eslint/eslint-plugin')
-const { parser } = require('typescript-eslint')
+const { parser, plugin } = require('typescript-eslint')
 
 const tsRedundant = require('./configs/ts-redundant')
 
@@ -21,6 +20,10 @@ const tsRedundant = require('./configs/ts-redundant')
  * @returns {import('@typescript-eslint/utils/ts-eslint').FlatConfig.Config}
  */
 function typescriptify (configs, options) {
+  if (typeof plugin.rules !== 'object') {
+    throw Error('Unexpected type of "plugin" export from "typescript-eslint"')
+  }
+
   const {
     files,
     ignores,
@@ -41,17 +44,23 @@ function typescriptify (configs, options) {
         deactivatedRules[ruleId] = 'off'
       }
     }
-    for (const [ruleId, ruleDefinition] of Object.entries(tsEslintPlugin.rules)) {
+    for (const [ruleId, ruleDefinition] of Object.entries(plugin.rules)) {
       const currentRule = config.rules?.[ruleId]
 
       if (currentRule === undefined) {
         continue
       }
 
-      if (!ruleDefinition.meta.docs?.extendsBaseRule) {
+      if (!('meta' in ruleDefinition) || !ruleDefinition.meta || !('docs' in ruleDefinition.meta) || !ruleDefinition.meta.docs || typeof ruleDefinition.meta.docs !== 'object') {
         continue
       }
-      if (ruleDefinition.meta.docs.requiresTypeChecking && !typeChecking) {
+
+      const docs = ruleDefinition.meta.docs
+
+      if (!('extendsBaseRule' in docs) || !docs.extendsBaseRule) {
+        continue
+      }
+      if ('requiresTypeChecking' in docs && docs.requiresTypeChecking && !typeChecking) {
         continue
       }
 
@@ -75,7 +84,7 @@ function typescriptify (configs, options) {
       },
     },
     plugins: {
-      '@typescript-eslint': tsEslintPlugin,
+      '@typescript-eslint': plugin,
     },
     rules: {
       ...deactivatedRules,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
         "@stylistic/eslint-plugin": "^2.6.0-beta.0",
-        "@typescript-eslint/eslint-plugin": "^8.0.0-alpha.34",
         "@typescript-eslint/utils": "^8.0.0-alpha.34",
         "eslint-plugin-n": "^17.9.0",
         "eslint-plugin-promise": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "prepublishOnly": "run-s build",
     "test-ci": "run-s test:*",
     "test:eslint": "eslint .",
+    "test:tseslint-extension": "eslint -c test/ts-extension-eslint.config.mjs test/test-types.d.ts",
     "test": "run-s check test:*"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
   "dependencies": {
     "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
     "@stylistic/eslint-plugin": "^2.6.0-beta.0",
-    "@typescript-eslint/eslint-plugin": "^8.0.0-alpha.34",
     "@typescript-eslint/utils": "^8.0.0-alpha.34",
     "eslint-plugin-n": "^17.9.0",
     "eslint-plugin-promise": "^6.4.0",

--- a/test/ts-extension-eslint.config.mjs
+++ b/test/ts-extension-eslint.config.mjs
@@ -1,0 +1,8 @@
+import neostandard, { plugins } from '../index.js'
+
+export default [
+  ...neostandard({
+    ts: true,
+  }),
+  ...plugins['typescript-eslint'].configs.recommended,
+]


### PR DESCRIPTION
…plugin`

It's actually where:

- complete shareable configurations are available
- configuration helper is available