### PR TITLE
fix: lazy load typescript and style options

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -12,9 +12,7 @@ const {
   modernizationStyles,
 } = require('./configs/modernization')
 const semiConfig = require('./configs/semi')
-const style = require('./configs/style')
 
-const { typescriptify } = require('./ts')
 const { isNonEmpty } = require('./utils')
 
 /**
@@ -81,7 +79,7 @@ function neostandard (options) {
   const styleConfigs = noStyle
     ? []
     : [
-        style,
+        require('./configs/style'),
         modernizationStyles,
         ...(semi ? [semiConfig] : []),
       ]
@@ -122,7 +120,7 @@ function neostandard (options) {
 
     // If targeting TypeScript, this will ensure those files are targeted with a TypeScript specific parser and any needed rule adaptions rules
     ...ts
-      ? [typescriptify(jsConfigs, {
+      ? [require('./ts').typescriptify(jsConfigs, {
           files: [
             '**/*.ts',
             ...noJsx ? [] : ['**/*.tsx'],


### PR DESCRIPTION
Eagerly loading those configs would eagerly load their plugins, which could cause compatibility issues like #124 and is also a waste of compute in general

Fixes #124