### PR TITLE
chore: improve renovate pattern matching

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -44,15 +44,9 @@
     },
     {
       "enabled": true,
-      "matchPackagePrefixes": [
-        "@typescript-eslint"
-      ],
       "matchPackageNames": [
-        "@stylistic/eslint-plugin",
-        "typescript-eslint",
-        "eslint-plugin-n",
-        "eslint-plugin-promise",
-        "eslint-plugin-react"
+        "/typescript-eslint/",
+        "/eslint-plugin/"
       ],
       "matchUpdateTypes": ["major"],
       "semanticCommitScope": "",
@@ -60,15 +54,9 @@
     },
     {
       "enabled": true,
-      "matchPackagePrefixes": [
-        "@typescript-eslint"
-      ],
       "matchPackageNames": [
-        "@stylistic/eslint-plugin",
-        "typescript-eslint",
-        "eslint-plugin-n",
-        "eslint-plugin-promise",
-        "eslint-plugin-react"
+        "/typescript-eslint/",
+        "/eslint-plugin/"
       ],
       "matchUpdateTypes": ["minor"],
       "semanticCommitType": "feat"


### PR DESCRIPTION
The `matchPackagePrefixes` has been replaced with using regexp and globs in `matchPackageNames` instead