### PR TITLE
ci: make `release-please` use bot app token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,15 +14,28 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       releaseCreated: ${{ steps.release.outputs.release_created }}
-    permissions:
-      contents: write
-      pull-requests: write
+    environment: sync
     steps:
+      # Generate bot token
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PEM }}
+
+      - name: Retrieve GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      # Release please
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           config-file: .github/release-please/config.json
           manifest-file: .github/release-please/manifest.json
+          token: ${{ steps.app-token.outputs.token }}
 
   npm_publish:
     name: Publish to npm


### PR DESCRIPTION
Enables GitHub Actions to be run on release PR:s and as such enables us to require tests to pass to merge a PR and as such enables us to activate auto-merge when all tests passes