### PR TITLE
fix: ignore jsx-rules in non-jsx files

### DIFF
--- a/dependents-data/known-failures/standard.json
+++ b/dependents-data/known-failures/standard.json
@@ -17,5 +17,6 @@
   "https://github.com/clinicjs/node-clinic-flame": "Fails for issue that should have existed with latest standard as well",
   "https://github.com/bitcoinjs/bolt11": "Fails for issue that should have existed with latest standard as well",
   "https://github.com/nvuillam/njre": "Fails because while it includes standard it also includes a vanilla ESLint 9 setup and megalinter, with megalinter being configured to use prettier and being the one that runs on CI",
-  "https://github.com/rom1504/node-mojangson": "Fails due to /* eslint-env mocha */"
+  "https://github.com/rom1504/node-mojangson": "Fails due to /* eslint-env mocha */",
+  "https://github.com/lquixada/cross-fetch": "Contains JSX-syntax in .js files"
 }

--- a/lib/configs/jsx.js
+++ b/lib/configs/jsx.js
@@ -3,8 +3,12 @@
 // @ts-ignore
 const react = require('eslint-plugin-react')
 
+const JSX_IGNORES = ['**/*.js', '**/*.mjs', '**/*.cjs', '**/*.ts']
+
 module.exports.jsx = /** @satisfies {import('eslint').Linter.Config} */ ({
   name: 'neostandard/jsx',
+
+  ignores: [...JSX_IGNORES],
 
   languageOptions: {
     parserOptions: {
@@ -60,6 +64,8 @@ module.exports.jsx = /** @satisfies {import('eslint').Linter.Config} */ ({
 
 module.exports.jsxStyles = /** @satisfies {import('eslint').Linter.Config} */ ({
   name: 'neostandard/style/jsx',
+
+  ignores: [...JSX_IGNORES],
 
   rules: {
     '@stylistic/jsx-quotes': ['error', 'prefer-single'],


### PR DESCRIPTION
Fixes #142

Related https://github.com/standard/standard/issues/1976

For those that use `neostandard` with additional non-jsx file types, they will still get the jsx-rules unless they deactivate jsx entirely, but I think that's fine – no need to add additional configuration options for that – too little to gain from that.