### PR TITLE
ci: remove cpx2 from known failures

### DIFF
--- a/dependents-data/known-failures/standard.json
+++ b/dependents-data/known-failures/standard.json
@@ -1,6 +1,5 @@
 {
   "https://github.com/bahmutov/simple-bin-help": "Fails because the standard command is fed a list of files to test, rather than using an ignore",
-  "https://github.com/bcomnes/cpx2": "Fails due to /* eslint-env mocha */",
   "https://github.com/dmonad/lib0": "Fails due to /* eslint-env browser */",
   "https://github.com/fastify/busboy": "Fails because @stylistic/ rule does not match /* eslint-disable object-property-newline */ ",
   "https://github.com/larsgw/sync-fetch": "Fails due to /* eslint-env browser */ and /* eslint-env mocha */",

--- a/dependents-data/neostandard-additional.ndjson
+++ b/dependents-data/neostandard-additional.ndjson
@@ -1,5 +1,6 @@
 {"repositoryUrl":"https://github.com/bcomnes/npm-run-all2"}
 {"repositoryUrl":"https://github.com/bcomnes/top-bun"}
+{"repositoryUrl":"https://github.com/bcomnes/cpx2"}
 {"repositoryUrl":"https://github.com/CFenner/MMM-Netatmo"}
 {"repositoryUrl":"https://github.com/fastify/fastify-multipart"}
 {"repositoryUrl":"https://github.com/fastify/fastify"}


### PR DESCRIPTION
And re-run `npm run dependents-filter`. Let me know if I missed anything.