### PR TITLE
fix: lazy load jsx options

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -4,10 +4,6 @@ const globals = require('globals')
 
 const base = require('./configs/base')
 const {
-  jsx,
-  jsxStyles,
-} = require('./configs/jsx')
-const {
   modernization,
   modernizationStyles,
 } = require('./configs/modernization')
@@ -69,12 +65,20 @@ function neostandard (options) {
     ...noJsx ? [] : ['**/*.jsx'],
   ]
 
-  const jsxConfigs = noJsx
-    ? []
-    : [
-        jsx,
-        ...(noStyle ? [] : [jsxStyles]),
-      ]
+  /** @type {import('eslint').Linter.Config[]} */
+  let jsxConfigs = []
+
+  if (!noJsx) {
+    const {
+      jsx,
+      jsxStyles,
+    } = require('./configs/jsx')
+
+    jsxConfigs = [
+      jsx,
+      ...(noStyle ? [] : [jsxStyles]),
+    ]
+  }
 
   const styleConfigs = noStyle
     ? []


### PR DESCRIPTION
This pull request changes from requiring the jsx configs and eslint-plugin-react at the top of the main file, to only requiring them when `noJsx` is `false`. A simlar thing was done for typescript here #126. `eslint-plugin-react` is quite heavy as it has quite a lot of files and also imports a bunch of dependencies, so it takes a non-trivial amount of time to import.

Timings for `time node ./test-changes.mjs`, where `test-changes.mjs` just imported the `./index.js` file and ran the neostandard function with `noJsx` set to `true` or `false`. I did also notice speed ups when using it in an eslint config file but it's harder to separate what time is actually spent on neostandard and what is spent loading eslint, the other plugins and doing the linting.

`noJsx: true`
original -> 1.61s
modified -> 1.25s

`noJsx: false`
original -> 1.61s
modified -> 1.69s