### PR TITLE
fix: pin `@stylistic/eslint-plugin` to `2.11.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   },
   "dependencies": {
     "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
-    "@stylistic/eslint-plugin": "^2.11.0",
+    "@stylistic/eslint-plugin": "2.11.0",
     "eslint-import-resolver-typescript": "^3.6.3",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-n": "^17.14.0",


### PR DESCRIPTION
Due to regression in `2.12.0`: https://github.com/eslint-stylistic/eslint-stylistic/issues/633