### PR TITLE
fix(main): fix `jsx-indent` deprecation

### DIFF
--- a/lib/configs/jsx.js
+++ b/lib/configs/jsx.js
@@ -84,7 +84,7 @@ module.exports.jsxStyles = /** @satisfies {import('eslint').Linter.Config} */ ({
     }],
     '@stylistic/jsx-equals-spacing': ['error', 'never'],
     '@stylistic/jsx-first-prop-new-line': ['error', 'multiline-multiprop'],
-    '@stylistic/jsx-indent': ['error', 2, {
+    '@stylistic/indent': ['error', 2, {
       checkAttributes: false,
       indentLogicalExpressions: true,
     }],


### PR DESCRIPTION
`@stylistic/eslint-plugin` v2.6.0 deprecated `@stylistic/jsx-indent` rule in favor of `@stylistic/indent`.

Since neostandard requires `@stylistic/eslint-plugin` 2.11, this is not a breaking change

Fix #232

Ref:
- https://github.com/eslint-stylistic/eslint-stylistic/blob/main/CHANGELOG.md#260-2024-07-31