### PR TITLE
feat: add ts file support in gitignore resolution

### DIFF
--- a/lib/resolve-gitignore.js
+++ b/lib/resolve-gitignore.js
@@ -11,6 +11,9 @@ const FLAT_CONFIG_FILENAMES = [
   'eslint.config.js',
   'eslint.config.mjs',
   'eslint.config.cjs',
+  'eslint.config.ts',
+  'eslint.config.mts',
+  'eslint.config.cts',
 ]
 
 /**


### PR DESCRIPTION
ESLint now natively supports typescript configuration files: https://eslint.org/docs/latest/use/configure/configuration-files#typescript-configuration-files

This fixes resolving gitignore relative to typescript config files.