### PR TITLE
fix(main): remove ignores from global scope

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -96,13 +96,6 @@ function neostandard (options) {
   ]
 
   return [
-    // To make it a global ignore, "ignores" has to be the lone key of the config, hence no "name": https://eslint.org/docs/latest/use/configure/configuration-files#globally-ignoring-files-with-ignores
-    ...ignores
-      ? [{
-          ignores,
-        }]
-      : [],
-
     // Config rules without any specified "files" matches all files matched by any other config (including the default rules). The sole purpose of this config is to add to the files those configs will match
     ...files.length
       ? [{
@@ -134,7 +127,10 @@ function neostandard (options) {
           name: 'neostandard/ts',
         })]
       : [],
-  ]
+  ].map(config => ({
+    ...config,
+    ignores: ignores || [],
+  }))
 }
 
 module.exports = {


### PR DESCRIPTION
Putting the passed ignores config as global breaks some use cases. Example use case is angular templates: I have to tell this library to ignore .html files, but since it's set globally, the angular template rules also ignore html.

If html files are not in ignore, the @stylistic rules will attempt to run on the html files regardless of the "files" or "filesTs" passed.