### PR TITLE
docs: add examples for all configuration options, CJS note, base example and a better table of content

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ alt="platformatic"
 
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
 - [Quick Start](#quick-start)
   - [Migrate from `standard`](#migrate-from-standard)
   - [Add to new project](#add-to-new-project)

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ All examples below use **ESM (ECMAScript Modules)** syntax. If you're using **Co
   module.exports = neostandard({ /* options */ })
   ```
 
-Here's a basic example of how to configure NeoStandard:
+Here's a basic example of how to configure `neostandard`:
 
   ```js
   import neostandard from 'neostandard'
@@ -123,7 +123,7 @@ Here's a basic example of how to configure NeoStandard:
   })
   ```
 
-The options below allow you to customize NeoStandard for your project. Use them to add global variables, ignore files, enable TypeScript support, and more.
+The options below allow you to customize `neostandard` for your project. Use them to add global variables, ignore files, enable TypeScript support, and more.
 
 * `env` - *`string[]`* - adds additional globals by importing them from the [globals](https://www.npmjs.com/package/globals) npm module
   
@@ -131,7 +131,7 @@ The options below allow you to customize NeoStandard for your project. Use them 
   import neostandard from 'neostandard'
 
   export default neostandard({
-    env: ['browser', 'node']  // Add browser and Node.js global variables
+    env: ['browser', 'mocha']  // Add browser and mocha global variables
   })
   ```
 
@@ -158,7 +158,7 @@ The options below allow you to customize NeoStandard for your project. Use them 
   
 * `globals` - *`string[] | object`* - an array of names of globals or an object of the same shape as ESLint [`languageOptions.globals`](https://eslint.org/docs/latest/use/configure/language-options#using-configuration-files)
   
-  Using an Array:
+  Using an array:
 
   ```js
   import neostandard from 'neostandard'

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Here's a basic example of how to configure `neostandard`:
   import neostandard from 'neostandard'
 
   export default neostandard({
-    ts: true  // an option
+    ts: true,  // an option
     // Add other options here
   })
   ```
@@ -131,7 +131,7 @@ The options below allow you to customize `neostandard` for your project. Use the
   import neostandard from 'neostandard'
 
   export default neostandard({
-    env: ['browser', 'mocha']  // Add browser and mocha global variables
+    env: ['browser', 'mocha'],  // Add browser and mocha global variables
   })
   ```
 
@@ -141,7 +141,7 @@ The options below allow you to customize `neostandard` for your project. Use the
   import neostandard from 'neostandard'
 
   export default neostandard({
-    files: ['src/**/*.js', 'tests/**/*.js']  // Lint only files in src/ and tests/ directories
+    files: ['src/**/*.js', 'tests/**/*.js'],  // Lint only files in src/ and tests/ directories
   })
   ```
 
@@ -152,7 +152,7 @@ The options below allow you to customize `neostandard` for your project. Use the
 
   export default neostandard({
     ts: true,   // Enable TypeScript support
-    filesTs: ['src/**/*.ts', 'tests/**/*.ts']  // Lint only TypeScript files in src/ and tests/ directories
+    filesTs: ['src/**/*.ts', 'tests/**/*.ts'],  // Lint only TypeScript files in src/ and tests/ directories
   })
   ```
   
@@ -164,7 +164,7 @@ The options below allow you to customize `neostandard` for your project. Use the
   import neostandard from 'neostandard'
 
   export default neostandard({
-    globals: ['$', 'jQuery']  // Treat $ and jQuery as global variables
+    globals: ['$', 'jQuery'],  // Treat $ and jQuery as global variables
   })
   ```
 
@@ -177,8 +177,8 @@ The options below allow you to customize `neostandard` for your project. Use the
     globals: {
       $: 'readonly',  // $ is a read-only global
       jQuery: 'writable',  // jQuery can be modified
-      localStorage: 'off'  // Disable the localStorage global
-    }
+      localStorage: 'off',  // Disable the localStorage global
+    },
   })
   ```
 
@@ -188,7 +188,7 @@ The options below allow you to customize `neostandard` for your project. Use the
   import neostandard from 'neostandard'
 
   export default neostandard({
-    ignores: ['dist/**/*', 'tests/**']  // Ignore files in dist/ and tests/ directories
+    ignores: ['dist/**/*', 'tests/**'],  // Ignore files in dist/ and tests/ directories
   })
   ```
 
@@ -198,7 +198,7 @@ The options below allow you to customize `neostandard` for your project. Use the
   import neostandard from 'neostandard'
 
   export default neostandard({
-    noJsx: true  // Disable JSX-specific rules
+    noJsx: true,  // Disable JSX-specific rules
   })
   ```
 
@@ -208,7 +208,7 @@ The options below allow you to customize `neostandard` for your project. Use the
   import neostandard from 'neostandard'
 
   export default neostandard({
-    noStyle: true  // Disable style-related rules (useful with Prettier or dprint)
+    noStyle: true,  // Disable style-related rules (useful with Prettier or dprint)
   })
   ```
 
@@ -218,7 +218,7 @@ The options below allow you to customize `neostandard` for your project. Use the
   import neostandard from 'neostandard'
 
   export default neostandard({
-    semi: true  // Enforce semicolons (like semistandard)
+    semi: true,  // Enforce semicolons (like semistandard)
   })
   ```
   
@@ -228,7 +228,7 @@ The options below allow you to customize `neostandard` for your project. Use the
   import neostandard from 'neostandard'
 
   export default neostandard({
-    ts: true  // Enable TypeScript support and lint .ts files
+    ts: true,  // Enable TypeScript support and lint .ts files
   })
   ```
 

--- a/README.md
+++ b/README.md
@@ -28,26 +28,27 @@ alt="platformatic"
 
 ## Table of Contents
 
-* [Quick Start](#quick-start)
-  * [Migrate from `standard`](#migrate-from-standard)
-  * [Add to new project](#add-to-new-project)
-* [Configuration options](#configuration-options)
-* [Extending](#extending)
-* [Additional exports](#additional-exports)
-  * [resolveIgnoresFromGitignore()](#resolveignoresfromgitignore)
-  * [Exported plugins](#exported-plugins)
-* [Missing for 1.0.0 release](#missing-for-100-release)
-* [Differences to standard / eslint-config-standard 17.x](#differences-to-standard--eslint-config-standard-17x)
-  * [Changed rules](#changed-rules)
-  * [Relaxed rules](#relaxed-rules)
-  * [Missing bits](#missing-bits)
-* [Config helper](#config-helper)
-  * [Config migration](#config-migration)
-* [Readme badges](#readme-badges)
-* [Mission statement](#mission-statement)
-  * [Rule guidelines](#rule-guidelines)
-* [Governance](#governance)
-* [Used by](#used-by)
+- [Table of Contents](#table-of-contents)
+- [Quick Start](#quick-start)
+  - [Migrate from `standard`](#migrate-from-standard)
+  - [Add to new project](#add-to-new-project)
+- [Configuration options](#configuration-options)
+- [Extending](#extending)
+- [Additional exports](#additional-exports)
+  - [resolveIgnoresFromGitignore()](#resolveignoresfromgitignore)
+  - [Exported plugins](#exported-plugins)
+    - [List of exported plugins](#list-of-exported-plugins)
+    - [Usage of exported plugin](#usage-of-exported-plugin)
+- [Missing for 1.0.0 release](#missing-for-100-release)
+- [Differences to standard / eslint-config-standard 17.x](#differences-to-standard--eslint-config-standard-17x)
+  - [Relaxed rules](#relaxed-rules)
+- [Config helper](#config-helper)
+  - [Config migration](#config-migration)
+- [Readme badges](#readme-badges)
+- [Mission statement](#mission-statement)
+  - [Rule guidelines](#rule-guidelines)
+- [Governance](#governance)
+- [Used by](#used-by)
 
 ## Quick Start
 
@@ -100,15 +101,137 @@ alt="platformatic"
 
 ## Configuration options
 
+All examples below use **ESM (ECMAScript Modules)** syntax. If you're using **CommonJS (CJS)**, replace the `import`/`export` statements with the following:
+
+  ```js
+  // Replace
+  import neostandard from 'neostandard'
+  export default neostandard({ /* options */ })
+
+  // With
+  const neostandard = require('neostandard')
+  module.exports = neostandard({ /* options */ })
+  ```
+
+Here's a basic example of how to configure NeoStandard:
+
+  ```js
+  import neostandard from 'neostandard'
+
+  export default neostandard({
+    ts: true  // an option
+    // Add other options here
+  })
+  ```
+
+The options below allow you to customize NeoStandard for your project. Use them to add global variables, ignore files, enable TypeScript support, and more.
+
 * `env` - *`string[]`* - adds additional globals by importing them from the [globals](https://www.npmjs.com/package/globals) npm module
+  
+  ```js
+  import neostandard from 'neostandard'
+
+  export default neostandard({
+    env: ['browser', 'node']  // Add browser and Node.js global variables
+  })
+  ```
+
 * `files` - *`string[]`* - additional file patterns to match. Uses the same shape as ESLint [`files`](https://eslint.org/docs/latest/use/configure/configuration-files#specifying-files-and-ignores)
+  
+  ```js
+  import neostandard from 'neostandard'
+
+  export default neostandard({
+    files: ['src/**/*.js', 'tests/**/*.js']  // Lint only files in src/ and tests/ directories
+  })
+  ```
+
 * `filesTs` - *`string[]`* - additional file patterns for the TypeScript configs to match. Uses the same shape as ESLint [`files`](https://eslint.org/docs/latest/use/configure/configuration-files#specifying-files-and-ignores)
+  
+  ```js
+  import neostandard from 'neostandard'
+
+  export default neostandard({
+    ts: true,   // Enable TypeScript support
+    filesTs: ['src/**/*.ts', 'tests/**/*.ts']  // Lint only TypeScript files in src/ and tests/ directories
+  })
+  ```
+  
 * `globals` - *`string[] | object`* - an array of names of globals or an object of the same shape as ESLint [`languageOptions.globals`](https://eslint.org/docs/latest/use/configure/language-options#using-configuration-files)
+  
+  Using an Array:
+
+  ```js
+  import neostandard from 'neostandard'
+
+  export default neostandard({
+    globals: ['$', 'jQuery']  // Treat $ and jQuery as global variables
+  })
+  ```
+
+  Using an object:
+
+  ```js
+  import neostandard from 'neostandard'
+
+  export default neostandard({
+    globals: {
+      $: 'readonly',  // $ is a read-only global
+      jQuery: 'writable',  // jQuery can be modified
+      localStorage: 'off'  // Disable the localStorage global
+    }
+  })
+  ```
+
 * `ignores` - *`string[]`* - an array of glob patterns for files that the config should not apply to, see [ESLint documentation](https://eslint.org/docs/latest/use/configure/ignore) for details
+  
+  ```js
+  import neostandard from 'neostandard'
+
+  export default neostandard({
+    ignores: ['dist/**/*', 'tests/**']  // Ignore files in dist/ and tests/ directories
+  })
+  ```
+
 * `noJsx` - *`boolean`* - if set, no jsx rules will be added. Useful if for some reason its clashing with your use of JSX-style syntax
+  
+  ```js
+  import neostandard from 'neostandard'
+
+  export default neostandard({
+    noJsx: true  // Disable JSX-specific rules
+  })
+  ```
+
 * `noStyle` - *`boolean`* - if set, no style rules will be added. Especially useful when combined with [Prettier](https://prettier.io/), [dprint](https://dprint.dev/) or similar
+  
+  ```js
+  import neostandard from 'neostandard'
+
+  export default neostandard({
+    noStyle: true  // Disable style-related rules (useful with Prettier or dprint)
+  })
+  ```
+
 * `semi` - *`boolean`* - if set, enforce rather than forbid semicolons (same as `semistandard` did)
+  
+  ```js
+  import neostandard from 'neostandard'
+
+  export default neostandard({
+    semi: true  // Enforce semicolons (like semistandard)
+  })
+  ```
+  
 * `ts` - *`boolean`* - if set, TypeScript syntax will be supported and `*.ts` (including `*.d.ts`) will be checked. To add additional file patterns to the TypeScript checks, use `filesTs`
+  
+  ```js
+  import neostandard from 'neostandard'
+
+  export default neostandard({
+    ts: true  // Enable TypeScript support and lint .ts files
+  })
+  ```
 
 ## Extending
 


### PR DESCRIPTION
This PR improves the documentation by:
1. Adding examples for all configuration options to make it easier for users to understand and use neostandard.
2. Including a note on converting ESM examples to CJS for users who prefer CommonJS.
3. Adding a base example to show the overall structure of a neostandard configuration.

Changes:
Added examples for `env`, `files`, `filesTs`, `globals`, `ignores`, `noJsx`, `noStyle`, `semi`, and `ts`.
Added a note explaining how to convert ESM examples to CJS.
Added a base example at the top of the Configuration Options section.

Why These Changes Are Helpful:
Beginner-Friendly: Clear examples reduce the learning curve.
Flexibility: The CJS note accommodates users who prefer CommonJS.
Reference: The base example provides a quick starting point for users.