### PR TITLE
chore: add missing strict directives

### DIFF
--- a/lib/configs/ts-redundant.js
+++ b/lib/configs/ts-redundant.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // From https://github.com/typescript-eslint/typescript-eslint/blob/d4504c849eaf309b795c63665cd2cdefa9eeb339/packages/eslint-plugin/src/configs/eslint-recommended-raw.ts#L23C1-L40C67
 module.exports = /** @type {Record<string, 'off'>} */ ({
   'getter-return': 'off', // ts(2378)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,5 @@
+'use strict'
+
 /**
  * Array.isArray() on its own give type any[]
  *


### PR DESCRIPTION
Only two CJS files without the `'use strict'` directive.