### PR TITLE
ci: add iconv-lite in dependents packages

### DIFF
--- a/dependents-data/neostandard-additional.ndjson
+++ b/dependents-data/neostandard-additional.ndjson
@@ -11,3 +11,4 @@
 {"repositoryUrl":"https://github.com/mcollina/tinysonic"}
 {"repositoryUrl":"https://github.com/mcollina/undici-thread-interceptor"}
 {"repositoryUrl":"https://github.com/mercurius-js/mercurius"}
+{"repositoryUrl":"https://github.com/pillarjs/iconv-lite"}


### PR DESCRIPTION
iconv-lite now uses neostandard while a linter is being decided in Express :)