### PR TITLE
feat!: Require Node.js `^20.19.0 || ^22.13.0 || >=24`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [18, 20, 22, 24]
+        target: [20, 22, 24, 25]
     name: Test on Node ${{ matrix.target }}
     uses: ./.github/workflows/reusable-npm-run.yml
     with:

--- a/.knip.jsonc
+++ b/.knip.jsonc
@@ -1,9 +1,5 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
-  "entry": [
-    "index.js",
-    "index.d.ts"
-  ],
   "ignore": [
     "test/should-*/**/*",
     "test/ts-extension-eslint.config.mjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "neostandard": "cli.mjs"
       },
       "devDependencies": {
-        "@types/node": "^18.19.130",
+        "@types/node": "^20.19.30",
         "@voxpelli/tsconfig": "^16.1.0",
         "eslint": "^9.39.2",
         "husky": "^9.1.7",
@@ -35,7 +35,7 @@
         "typescript": "~5.9.3"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "peerDependencies": {
         "eslint": "^9.0.0"
@@ -1000,13 +1000,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "version": "20.19.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
+      "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -6935,9 +6935,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "keywords": [],
   "license": "MIT",
   "engines": {
-    "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+    "node": "^20.19.0 || ^22.13.0 || >=24"
   },
   "bin": {
     "neostandard": "cli.mjs"
@@ -68,7 +68,7 @@
     "test": "run-s check test:*"
   },
   "devDependencies": {
-    "@types/node": "^18.19.130",
+    "@types/node": "^20.19.30",
     "@voxpelli/tsconfig": "^16.1.0",
     "eslint": "^9.39.2",
     "husky": "^9.1.7",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@voxpelli/tsconfig/node18.json",
+  "extends": "@voxpelli/tsconfig/node20.json",
   "files": [
     "cli.mjs",
     "eslint.config.js",


### PR DESCRIPTION
Aligns with ESLint 10 (https://github.com/eslint/eslint/pull/20160) and unblocks eg. #294 #324

Doesn't mean that we should drop ESLint 9, but it would be nice to align with current LTS versions of Node.js if possible.

Does any of @bcomnes, @mcollina, @wesleytodd or anyone else see any issue with this?

