### PR TITLE
fix(style): ignore TSTypeParameterInstantiation indent

### DIFF
--- a/lib/configs/style.js
+++ b/lib/configs/style.js
@@ -46,7 +46,11 @@ export default /** @satisfies {import('eslint').Linter.Config} */ ({
       // JSX nodes were previously ignored here and handled by the (now removed)
       // @stylistic/jsx-indent rule; @stylistic/indent handles JSX natively
       // (eslint-stylistic #447 deprecated jsx-indent in favour of indent; #1019 removed it)
-      ignoredNodes: ['TemplateLiteral *'],
+      ignoredNodes: [
+        'TemplateLiteral *',
+        // Opts out these from linting to avoid the regression noted in #393
+        'TSTypeParameterInstantiation',
+      ],
       // Restores pre-2.12 indentation behaviour (eslint-stylistic #633 regression / #636).
       // v5 object form of the former `offsetTernaryExpressions: true` + `offsetTernaryExpressionsOffsetCallExpressions: false`.
       offsetTernaryExpressions: { CallExpression: false, AwaitExpression: false, NewExpression: false },


### PR DESCRIPTION
Add `TSTypeParameterInstantiation` to the `ignoredNodes` of the `@stylistic/indent` rule to avoid the indentation change that appeared as a breaking change for #393.